### PR TITLE
Update uses page and remove Notes nav tab

### DIFF
--- a/about.html
+++ b/about.html
@@ -122,7 +122,6 @@
       <a href="/photos">Photos</a>
       <a href="/about" class="active">About</a>
       <a href="/uses">Uses</a>
-      <a href="/notes">Notes</a>
       <a href="/stack">Stack</a>
       <a href="/contact">Contact</a>
       </nav>

--- a/contact.html
+++ b/contact.html
@@ -104,7 +104,6 @@
       <a href="/photos">Photos</a>
       <a href="/about">About</a>
       <a href="/uses">Uses</a>
-      <a href="/notes">Notes</a>
       <a href="/stack">Stack</a>
       <a href="/contact" class="active">Contact</a>
       </nav>

--- a/index.html
+++ b/index.html
@@ -176,7 +176,6 @@
       <a href="/photos">Photos</a>
       <a href="/about">About</a>
       <a href="/uses">Uses</a>
-      <a href="/notes">Notes</a>
       <a href="/stack">Stack</a>
       <a href="/contact">Contact</a>
       </nav>

--- a/notes.html
+++ b/notes.html
@@ -118,7 +118,7 @@
     <a href="/" class="logo">the<span>alx</span>labs ⚗️</a>
     <div class="nav-right">
       <nav class="nav-links">
-        <a href="/">Home</a><a href="/projects">Projects</a><a href="/photos">Photos</a><a href="/about">About</a><a href="/uses">Uses</a><a href="/notes" class="active">Notes</a><a href="/stack">Stack</a><a href="/contact">Contact</a>
+        <a href="/">Home</a><a href="/projects">Projects</a><a href="/photos">Photos</a><a href="/about">About</a><a href="/uses">Uses</a><a href="/stack">Stack</a><a href="/contact">Contact</a>
       </nav>
       <div class="nav-divider"></div>
       <div class="status-pill"><div class="status-dot"></div><span class="live-clock" id="clock"></span></div>

--- a/photos.html
+++ b/photos.html
@@ -110,7 +110,6 @@
         <a href="/photos" class="active">Photos</a>
         <a href="/about">About</a>
         <a href="/uses">Uses</a>
-        <a href="/notes">Notes</a>
         <a href="/stack">Stack</a>
         <a href="/contact">Contact</a>
       </nav>

--- a/projects.html
+++ b/projects.html
@@ -118,7 +118,6 @@
       <a href="/photos">Photos</a>
       <a href="/about">About</a>
       <a href="/uses">Uses</a>
-      <a href="/notes">Notes</a>
       <a href="/stack">Stack</a>
       <a href="/contact">Contact</a>
       </nav>

--- a/stack.html
+++ b/stack.html
@@ -96,7 +96,6 @@
       <a href="/photos">Photos</a>
       <a href="/about">About</a>
       <a href="/uses">Uses</a>
-      <a href="/notes">Notes</a>
       <a href="/stack" class="active">Stack</a>
       <a href="/contact">Contact</a>
       </nav>

--- a/uses.html
+++ b/uses.html
@@ -91,7 +91,7 @@
     <a href="/" class="logo">the<span>alx</span>labs ⚗️</a>
     <div class="nav-right">
       <nav class="nav-links">
-        <a href="/">Home</a><a href="/projects">Projects</a><a href="/photos">Photos</a><a href="/about">About</a><a href="/uses" class="active">Uses</a><a href="/notes">Notes</a><a href="/stack">Stack</a><a href="/contact">Contact</a>
+        <a href="/">Home</a><a href="/projects">Projects</a><a href="/photos">Photos</a><a href="/about">About</a><a href="/uses" class="active">Uses</a><a href="/stack">Stack</a><a href="/contact">Contact</a>
       </nav>
       <div class="nav-divider"></div>
       <div class="status-pill"><div class="status-dot"></div><span class="live-clock" id="clock"></span></div>
@@ -122,25 +122,22 @@
     <div class="uses-sections">
 
       <div class="uses-section" id="hardware">
-        <div class="uses-section-header"><span class="uses-section-icon">💻</span><span class="uses-section-title">Hardware</span><span class="uses-section-count">5 items</span></div>
+        <div class="uses-section-header"><span class="uses-section-icon">💻</span><span class="uses-section-title">Hardware</span><span class="uses-section-count">3 items</span></div>
         <div class="uses-items">
-          <div class="use-item"><div><div class="use-name">MacBook Pro</div><div class="use-desc">The main machine. Does everything without complaint. Dark mode always, display brightness at 60%.</div></div><span class="use-badge badge-daily">Daily Driver</span></div>
-          <div class="use-item"><div><div class="use-name">External Monitor</div><div class="use-desc">Extra screen real estate for when the code gets big. Positioned portrait mode for reading docs.</div></div><span class="use-badge badge-daily">Daily</span></div>
-          <div class="use-item"><div><div class="use-name">Mechanical Keyboard</div><div class="use-desc">Tactile switches. The click is important. It tells your brain something is happening.</div></div><span class="use-badge badge-fav">Favourite</span></div>
-          <div class="use-item"><div><div class="use-name">Magic Trackpad</div><div class="use-desc">Gestures are genuinely good. No mouse needed when the trackpad is this well-designed.</div></div><span class="use-badge badge-daily">Daily</span></div>
-          <div class="use-item"><div><div class="use-name">Sony WH-1000XM4</div><div class="use-desc">Noise cancellation for when the city gets loud. Required for deep work sessions.</div></div><span class="use-badge badge-fav">Can't live without</span></div>
+          <div class="use-item"><div><div class="use-name">MacBook Air</div><div class="use-desc">The main machine. Thin, silent, does everything without complaint. Dark mode always, display brightness at 60%.</div></div><span class="use-badge badge-daily">Daily Driver</span></div>
+          <div class="use-item"><div><div class="use-name">Magic Mouse</div><div class="use-desc">Clean, minimal, flat. It looks good on the desk and that matters. Not ergonomic but stylish.</div></div><span class="use-badge badge-daily">Daily</span></div>
+          <div class="use-item"><div><div class="use-name">AirPods Max</div><div class="use-desc">Noise cancellation for when the city gets loud. Over-ear, premium sound. Required for deep work sessions.</div></div><span class="use-badge badge-fav">Can't live without</span></div>
         </div>
       </div>
 
       <div class="uses-section" id="software">
-        <div class="uses-section-header"><span class="uses-section-icon">🖥️</span><span class="uses-section-title">Software</span><span class="uses-section-count">6 items</span></div>
+        <div class="uses-section-header"><span class="uses-section-icon">🖥️</span><span class="uses-section-title">Software</span><span class="uses-section-count">5 items</span></div>
         <div class="uses-items">
           <div class="use-item"><div><div class="use-name">VS Code</div><div class="use-desc">Default editor. Dark theme, custom font, all the extensions. It's not glamorous but it works.</div></div><span class="use-badge badge-daily">Daily</span></div>
           <div class="use-item"><div><div class="use-name">Figma</div><div class="use-desc">Design tool of choice. Where everything starts before it becomes code. Auto Layout is a gift.</div></div><span class="use-badge badge-fav">Favourite</span></div>
-          <div class="use-item"><div><div class="use-name">Arc Browser</div><div class="use-desc">The only browser that doesn't feel like a compromise. Spaces for organizing work. Tabs hidden away.</div></div><span class="use-badge badge-new">Recent switch</span></div>
+          <div class="use-item"><div><div class="use-name">Opera</div><div class="use-desc">Browser of choice. Built-in VPN, sidebar, fast. Does what it needs to without getting in the way.</div></div><span class="use-badge badge-daily">Daily</span></div>
           <div class="use-item"><div><div class="use-name">Raycast</div><div class="use-desc">Spotlight but actually good. Calculator, clipboard history, window management — all from one shortcut.</div></div><span class="use-badge badge-fav">Essential</span></div>
-          <div class="use-item"><div><div class="use-name">Warp Terminal</div><div class="use-desc">Modern terminal that understands what you're doing. Command history with context. Actually helpful.</div></div><span class="use-badge badge-new">New</span></div>
-          <div class="use-item"><div><div class="use-name">Obsidian</div><div class="use-desc">Where thoughts go before they become projects. Linked notes, no cloud sync, full ownership.</div></div><span class="use-badge badge-daily">Daily</span></div>
+          <div class="use-item"><div><div class="use-name">Notion</div><div class="use-desc">Where everything gets organised. Pages, databases, notes — the whole second brain lives here.</div></div><span class="use-badge badge-daily">Daily</span></div>
         </div>
       </div>
 
@@ -148,7 +145,7 @@
         <div class="uses-section-header"><span class="uses-section-icon">⚡</span><span class="uses-section-title">Coding Tools</span><span class="uses-section-count">5 items</span></div>
         <div class="uses-items">
           <div class="use-item"><div><div class="use-name">Vercel</div><div class="use-desc">Where everything ships. Git push to deploy. Preview URLs for every branch. Free tier is generous.</div></div><span class="use-badge badge-fav">Always</span></div>
-          <div class="use-item"><div><div class="use-name">GitHub</div><div class="use-desc">Version control, issues, actions. The whole pipeline lives here. Commit often, commit descriptively.</div></div><span class="use-badge badge-daily">Daily</span></div>
+          <div class="use-item"><div><div class="use-name">GitHub Pro</div><div class="use-desc">Version control, issues, actions. The whole pipeline lives here. Pro for private repos and extra features. Commit often, commit descriptively.</div></div><span class="use-badge badge-daily">Daily</span></div>
           <div class="use-item"><div><div class="use-name">Supabase</div><div class="use-desc">Backend when I need one. Postgres, auth, storage — all in one dashboard. Open source too.</div></div><span class="use-badge badge-free">Free Tier</span></div>
           <div class="use-item"><div><div class="use-name">Tailwind CSS</div><div class="use-desc">Utility classes that compile to nothing unused. Fast to write, easy to read, zero custom CSS needed.</div></div><span class="use-badge badge-daily">Daily</span></div>
           <div class="use-item"><div><div class="use-name">pnpm</div><div class="use-desc">Faster npm. Uses symlinks, saves disk space, installs in half the time. Hard to go back.</div></div><span class="use-badge badge-fav">Switched</span></div>
@@ -156,22 +153,18 @@
       </div>
 
       <div class="uses-section" id="camera">
-        <div class="uses-section-header"><span class="uses-section-icon">📷</span><span class="uses-section-title">Camera Gear</span><span class="uses-section-count">4 items</span></div>
+        <div class="uses-section-header"><span class="uses-section-icon">📷</span><span class="uses-section-title">Camera Gear</span><span class="uses-section-count">3 items</span></div>
         <div class="uses-items">
           <div class="use-item"><div><div class="use-name">Nikon D3200</div><div class="use-desc">24.2MP APS-C sensor. Got it used, never looked back. Not the newest but it captures exactly what I see.</div></div><span class="use-badge badge-fav">Main body</span></div>
           <div class="use-item"><div><div class="use-name">55mm f/1.8 Prime</div><div class="use-desc">The only lens I need. 55mm on APS-C is close to what your eyes actually see. Prime means you move your feet.</div></div><span class="use-badge badge-fav">Always on</span></div>
-          <div class="use-item"><div><div class="use-name">Peak Design Strap</div><div class="use-desc">The strap that ships with cameras is an insult. This one clicks in and out in a second. Worth every cent.</div></div><span class="use-badge badge-daily">Daily</span></div>
           <div class="use-item"><div><div class="use-name">Lightroom Classic</div><div class="use-desc">Post-processing. Minimal adjustments — the goal is to capture it right, not fix it after. But exposure correction is real.</div></div><span class="use-badge badge-daily">When needed</span></div>
         </div>
       </div>
 
       <div class="uses-section" id="desk">
-        <div class="uses-section-header"><span class="uses-section-icon">🪑</span><span class="uses-section-title">Desk Setup</span><span class="uses-section-count">4 items</span></div>
+        <div class="uses-section-header"><span class="uses-section-icon">🪑</span><span class="uses-section-title">Desk Setup</span><span class="uses-section-count">1 item</span></div>
         <div class="uses-items">
-          <div class="use-item"><div><div class="use-name">Standing Desk</div><div class="use-desc">Motor-driven. Programmed heights for sit and stand. Sit more than I should, stand when the code isn't working.</div></div><span class="use-badge badge-daily">Daily</span></div>
-          <div class="use-item"><div><div class="use-name">Desk Mat</div><div class="use-desc">Oversized, dark. Covers the entire surface. Makes the desk feel intentional instead of accidental.</div></div><span class="use-badge badge-fav">Underrated</span></div>
-          <div class="use-item"><div><div class="use-name">Desk Lamp</div><div class="use-desc">Warm light, positioned to the side. Screen glare is a productivity killer. Good lighting is not negotiable.</div></div><span class="use-badge badge-daily">Daily</span></div>
-          <div class="use-item"><div><div class="use-name">Cable Management</div><div class="use-desc">Velcro ties, cable routing under the desk. A clean desk is a clear mind. 45 minutes of setup, infinite peace.</div></div><span class="use-badge badge-fav">One-time fix</span></div>
+          <div class="use-item"><div><div class="use-name">Cable Chaos</div><div class="use-desc">Zero cable management. Cables go where they want. The desk is a beautiful disaster and that's fine. The code still ships.</div></div><span class="use-badge badge-new">Permanent state</span></div>
         </div>
       </div>
 
@@ -179,7 +172,7 @@
         <div class="uses-section-header"><span class="uses-section-icon">🌐</span><span class="uses-section-title">Services</span><span class="uses-section-count">4 items</span></div>
         <div class="uses-items">
           <div class="use-item"><div><div class="use-name">thealxlabs.ca</div><div class="use-desc">The .ca domain for the lab. Canadian TLD because Toronto is home. All subdomains live here.</div></div><span class="use-badge badge-fav">Home base</span></div>
-          <div class="use-item"><div><div class="use-name">Vercel (Pro)</div><div class="use-desc">Hosting for everything. Analytics, edge functions, custom domains — worth the monthly cost for the speed alone.</div></div><span class="use-badge badge-daily">Every project</span></div>
+          <div class="use-item"><div><div class="use-name">Vercel</div><div class="use-desc">Hosting for everything. Git push to deploy. Preview URLs for every branch. The free tier handles it all.</div></div><span class="use-badge badge-daily">Every project</span></div>
           <div class="use-item"><div><div class="use-name">Spotify</div><div class="use-desc">Essential. Lo-fi for focus, drum and bass when the deadline is close. The playlist changes, the headphones don't come off.</div></div><span class="use-badge badge-daily">Always on</span></div>
           <div class="use-item"><div><div class="use-name">1Password</div><div class="use-desc">Password manager. Every password is unique and random. Security hygiene is non-negotiable once you've been burned.</div></div><span class="use-badge badge-fav">Essential</span></div>
         </div>


### PR DESCRIPTION
- Uses/Hardware: MacBook Air (was Pro), Magic Mouse (was Trackpad), AirPods Max (was Sony); removed monitor and keyboard
- Uses/Software: Opera (was Arc), Notion (was Obsidian); removed Warp Terminal
- Uses/Coding: GitHub upgraded to GitHub Pro
- Uses/Camera: removed Peak Design Strap (3 items)
- Uses/Desk: removed standing desk, desk mat, desk lamp; replaced cable mgmt with Cable Chaos
- Uses/Services: Vercel Pro to Vercel free tier
- Nav: removed Notes tab from all 8 pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Notes from site navigation across all pages
  * Updated Uses page with current equipment and software preferences, including MacBook Air, Magic Mouse, AirPods Max, and various development tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->