### PR TITLE
fix: isolate events API error so repos always render on projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -244,35 +244,45 @@
         </a>`;
       }).join('');
 
-      // Fetch recent commits across all repos (events API)
-      const evRes = await fetch(`https://api.github.com/users/${GH_USER}/events/public?per_page=30`);
-      const events = await evRes.json();
-
-      const pushEvents = events
-        .filter(e => e.type === 'PushEvent')
-        .flatMap(e => e.payload.commits.map(c => ({
-          repo: e.repo.name.replace(`${GH_USER}/`, ''),
-          message: c.message.split('\n')[0],
-          date: e.created_at,
-          url: `https://github.com/${e.repo.name}/commit/${c.sha}`
-        })))
-        .slice(0, 12);
-
-      document.getElementById('commitSub').textContent = `// ${pushEvents.length} recent commits · live from GitHub`;
       document.getElementById('projCount').textContent = ownRepos.length;
-      document.getElementById('commitCount').textContent = pushEvents.length;
       document.getElementById('tabBar').style.display = '';
 
-      document.getElementById('commitsList').innerHTML = pushEvents.length
-        ? pushEvents.map(c => `
-          <div class="changelog-item">
-            <div class="changelog-date" style="font-size:0.56rem">${timeAgo(c.date)}</div>
-            <div class="changelog-content">
-              <span class="changelog-badge badge-update" style="margin-bottom:4px">${c.repo}</span>
-              <div class="changelog-title"><a href="${c.url}" target="_blank" style="color:inherit;text-decoration:none">${c.message}</a></div>
-            </div>
-          </div>`).join('')
-        : '<div class="changelog-item"><div class="changelog-date">—</div><div class="changelog-content"><div class="changelog-title">No recent commits found.</div></div></div>';
+      // Fetch recent commits across all repos (events API) — isolated so failures don't break repos
+      try {
+        const evRes = await fetch(`https://api.github.com/users/${GH_USER}/events/public?per_page=30`);
+        if (!evRes.ok) throw new Error(`GitHub Events API ${evRes.status}`);
+        const events = await evRes.json();
+
+        const pushEvents = Array.isArray(events)
+          ? events
+              .filter(e => e.type === 'PushEvent')
+              .flatMap(e => e.payload.commits.map(c => ({
+                repo: e.repo.name.replace(`${GH_USER}/`, ''),
+                message: c.message.split('\n')[0],
+                date: e.created_at,
+                url: `https://github.com/${e.repo.name}/commit/${c.sha}`
+              })))
+              .slice(0, 12)
+          : [];
+
+        document.getElementById('commitSub').textContent = `// ${pushEvents.length} recent commits · live from GitHub`;
+        document.getElementById('commitCount').textContent = pushEvents.length;
+
+        document.getElementById('commitsList').innerHTML = pushEvents.length
+          ? pushEvents.map(c => `
+            <div class="changelog-item">
+              <div class="changelog-date" style="font-size:0.56rem">${timeAgo(c.date)}</div>
+              <div class="changelog-content">
+                <span class="changelog-badge badge-update" style="margin-bottom:4px">${c.repo}</span>
+                <div class="changelog-title"><a href="${c.url}" target="_blank" style="color:inherit;text-decoration:none">${c.message}</a></div>
+              </div>
+            </div>`).join('')
+          : '<div class="changelog-item"><div class="changelog-date">—</div><div class="changelog-content"><div class="changelog-title">No recent commits found.</div></div></div>';
+      } catch (evErr) {
+        document.getElementById('commitSub').textContent = `// commits unavailable: ${evErr.message}`;
+        document.getElementById('commitCount').textContent = '—';
+        document.getElementById('commitsList').innerHTML = '<div class="changelog-item"><div class="changelog-date">—</div><div class="changelog-content"><div class="changelog-title">Could not load commits. GitHub may be rate limiting — try again shortly.</div></div></div>';
+      }
 
     } catch (err) {
       setStatus(false, `GitHub API error: ${err.message} — showing cached data`);


### PR DESCRIPTION
The events API fetch had no .ok check and no Array.isArray() guard. If GitHub rate-limited the events endpoint, the thrown error was caught by the outer catch block which also wiped out the projects grid. Now the events fetch runs in its own try/catch so a failure only affects the commits tab, never the repos panel.

Fixes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for repository commit data. The commits section now gracefully manages GitHub API failures and displays a fallback message when data is unavailable instead of breaking the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->